### PR TITLE
Ctrade 1839 handle unique queues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinify/rabbitmq",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Coinify RabbitMQ client with support for events and tasks",
   "main": "dist/index.js",
   "types": "dist/index",

--- a/src/messageTypes/Event.ts
+++ b/src/messageTypes/Event.ts
@@ -15,6 +15,7 @@ export type EventConsumerFunction<Context = any, Result = any> = (context: Conte
 export interface EventConsumer<Context = any, Result = any> {
   type: 'event';
   consumerTag: string;
+  queueName: string;
   key: string;
   consumeFn: EventConsumerFunction<Context, Result>;
   options?: RegisterEventConsumerOptions;

--- a/src/messageTypes/Task.ts
+++ b/src/messageTypes/Task.ts
@@ -16,6 +16,7 @@ export type TaskConsumerFunction<Context = any, Result = any> = (context: Contex
 
 export interface TaskConsumer<Context = any, Result = any> {
   type: 'task';
+  queueName: string;
   consumerTag: string;
   key: string;
   consumeFn: TaskConsumerFunction<Context, Result>;

--- a/test/unit/CoinifyRabbit/_recreateRegisteredConsumers.test.ts
+++ b/test/unit/CoinifyRabbit/_recreateRegisteredConsumers.test.ts
@@ -9,21 +9,21 @@ describe('CoinifyRabbit', () => {
     // TODO Test for prefetch option
 
     let rabbit: any,
-      registerEventConsumerStub: sinon.SinonStub,
-      registerTaskConsumerStub: sinon.SinonStub;
+      bindEventConsumerStub: sinon.SinonStub,
+      bindTaskConsumerStub: sinon.SinonStub;
 
     beforeEach(() => {
       rabbit = new CoinifyRabbit();
 
-      registerEventConsumerStub = sinon.stub(rabbit, 'registerEventConsumer');
-      registerEventConsumerStub.resolves();
-      registerTaskConsumerStub = sinon.stub(rabbit, 'registerTaskConsumer');
-      registerTaskConsumerStub.resolves();
+      bindEventConsumerStub = sinon.stub(rabbit, 'bindEventConsumer');
+      bindEventConsumerStub.resolves();
+      bindTaskConsumerStub = sinon.stub(rabbit, 'bindTaskConsumer');
+      bindTaskConsumerStub.resolves();
     });
 
     afterEach(() => {
-      registerEventConsumerStub.restore();
-      registerTaskConsumerStub.restore();
+      bindEventConsumerStub.restore();
+      bindTaskConsumerStub.restore();
     });
 
     it('should empty list of registered consumers and re-create them', async () => {
@@ -39,17 +39,17 @@ describe('CoinifyRabbit', () => {
 
       expect(rabbit.consumers).to.have.lengthOf(0);
 
-      expect(registerEventConsumerStub.callCount).to.equal(3);
+      expect(bindEventConsumerStub.callCount).to.equal(3);
       let i = 0;
       for (const { key, consumerTag, consumeFn, options } of [ eventConsumer1, eventConsumer2, eventConsumer3 ]) {
-        expect(registerEventConsumerStub.getCall(i).args).to.deep.equal([ key, consumeFn, { ...options, consumerTag } ]);
+        expect(bindEventConsumerStub.getCall(i).args).to.deep.equal([ key, consumeFn, { ...options, consumerTag } ]);
         i++;
       }
 
-      expect(registerTaskConsumerStub.callCount).to.equal(2);
+      expect(bindTaskConsumerStub.callCount).to.equal(2);
       i = 0;
       for (const { key, consumerTag, consumeFn, options } of [ taskConsumer1, taskConsumer2 ]) {
-        expect(registerTaskConsumerStub.getCall(i).args).to.deep.equal([ key, consumeFn, { ...options, consumerTag } ]);
+        expect(bindTaskConsumerStub.getCall(i).args).to.deep.equal([ key, consumeFn, { ...options, consumerTag } ]);
         i++;
       }
     });


### PR DESCRIPTION
Instead of deleting the unique queues and possibly loose messages, I have changed it so that the specific service reconnects to its unique queue instead. if it has been delete a new unique queue will be created. 

Every unque queue has 10 character random prefix. This is now stored in the consumer list for reconnecting, so they can reconnect to the same queue